### PR TITLE
Fix guest user feature errors

### DIFF
--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -74,9 +74,18 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   const logout = async () => {
+    loading.value = true
+    error.value = null
+
+    // For guest users, simply clear local state without calling the backend
+    if (user.value?.googleId === 'guest') {
+      user.value = null
+      localStorage.removeItem('user')
+      loading.value = false
+      return
+    }
+
     try {
-      loading.value = true
-      error.value = null
       await axios.post(`${API_BASE_URL}/api/auth/logout`)
       user.value = null
       localStorage.removeItem('user')


### PR DESCRIPTION
Fix guest user logout by preventing unnecessary API call.

Guest users were attempting to call the backend logout endpoint, which is not designed for them, leading to errors. This change ensures guest users' local state is cleared directly without a backend interaction.